### PR TITLE
Fix parsing out json object

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -82,12 +82,15 @@ Reporter.prototype = {
       // record err message & stack trace into report
       try {
         var s = test.stdout.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
-        // remove Magellan debug info
-        s = s.replace(/Magellan child process start/, '')
         // remove timestamp added by Magellan before each line
         s = s.split('\n').map(function (line) {
           return line.substr(9);
         }).join('\n');
+        passesIndex = s.indexOf('"passes": [');
+        endOfPasses = s.indexOf(']', passesIndex);
+        s = s.substring(0, s.indexOf('}', endOfPasses) + 1); // Remove everything after the last closing curly brace
+        s = '{' + s.substring(s.indexOf('"stats"')); // Remove everything before {"stats"
+        s = s.replace(/(\r\n|\n|\r)/gm, ''); // Remove all line breaks
         testObject.err = JSON.parse(s).failures[0].err;
       } catch (err) {
         testObject.err = 'Unknown error (test was killed?) ' + err;


### PR DESCRIPTION
Removes anything before the JSON object
Removes anything after the JSON object
Removes line breaks - See test.stdout snippet below which I saw a line break cause an issue. You see two timestamps , but it should be on the same line , since its the same stack trace.

13:36:00         "stack": "AssertionError: expected true to equal false\n---------------------------------------------\n    at requestTick (node_modules/q/q.js:197:21)\n    at Function.nextTick (node_modules/q/q.js:180:13)\n    at node_modules/q/q.js:603:15\n    at Array.reduce (native)\n    at node_modules/q/q.js:263:21\n    at become (node_modules/q/q.js:602:9)\n    at deferred.resolve (node_modules/q/q.js:618:9)\n    at node_modules/q/q.js:663:18\n    at cb (node_modules/wd/lib/element.js:48:24)\n    at node_modules/wd/lib/callbacks.js:105:5\n    at node_modules/wd/lib/callbacks.js:82:7\n    at node_modules/wd/lib/webdriver.js:174:5\n    at Request._callback (node_modules/wd/lib/http-utils.js:87:7)\n    at Request.self.callback (node_modules/wd/node_modules/request/request.js:368:22)\n    at Request.<anonymous> (node_modules/wd/node_modules/request/request.js:1219:14)\n    at IncomingMessage.<anonymous> (node_modules/wd/node_modules/request/request.js:1167:12)\n    at endReadableNT (_stream_readable.js:913:12)\n---------------------------------------------\n    at Request.init (node_modules/wd/node_modules/request/request.js:371:10)\n    at new Request (node_modules/wd/node_modules/request/request.js:272:8)\n    at request (node_modules/wd/node_modules/request/index.js:56:10)\n    at Object.requestWithRetry (node_modules/wd/lib/http-utils.js:74:3)\n    at [object Object].Webdriver._jsonWireCall (node_modules/wd/lib/webdriver.js:171:13)\n    at [object Object].commands.isDisplayed (node_modules/wd/lib/commands.js:1382:8)\n    at [object Object].elementCommands.isDisplayed (node_modules/wd/lib/element-commands.js:196:24)\n    at [object Object].Element.(anonymous function) [as isDisplayed](node_modules/wd/lib/element.js:52:15)\n    at [object Object].isDisplayed (node_modules/wd/lib/promise-webdriver.js:60:10)\n    at node_modules/wd/lib/pr
#13:36:00 omise-webdriver.js:185:32\n    at _fulfilled (node_modules/q/q.js:834:54)\n    at self.promiseDispatch.done (node_modules/q/q.js:863:30)\n    at Promise.promise.promiseDispatch (node_modules/q/q.js:796:13)\n    at node_modules/q/q.js:604:44\n    at runSingle (node_modules/q/q.js:137:13)\n    at flush (node_modules/q/q.js:125:13)\n---------------------------------------------\n    at requestTick (node_modules/q/q.js:197:21)\n    at Function.nextTick (node_modules/q/q.js:180:13)\n    at node_modules/q/q.js:603:15\n    at Array.reduce (native)\n    at node_modules/q/q.js:263:21\n    at become (node_modules/q/q.js:602:9)\n    at deferred.resolve (node_modules/q/q.js:618:9)\n    at node_modules/q/q.js:663:18\n    at cb (node_modules/wd/lib/webdriver.js:221:45)\n    at node_modules/wd/lib/callbacks.js:140:5\n    at node_modules/wd/lib/callbacks.js:82:7\n    at node_modules/wd/lib/webdriver.js:174:5\n    at Request._callback (node_modules/wd/lib/http-utils.js:87:7)\n    at Request.self.callback (node_modules/wd/node_modules/request/request.js:368:22)\n    at Request.<anonymous> (node_modules/wd/node_modules/request/request.js:1219:14)\n    at IncomingMessage.<anonymous> (node_modules/wd/node_modules/request/request.js:1167:12)\n    at endReadableNT (_stream_readable.js:913:12)\n---------------------------------------------\n    at Request.init (node_modules/wd/node_modules/request/request.js:371:10)\n    at new Request (node_modules/wd/node_modules/request/request.js:272:8)\n    at request (node_modules/wd/node_modules/request/index.js:56:10)\n    at Object.requestWithRetry (node_modules/wd/lib/http-utils.js:74:3)\n    at [object Object].Webdriver._jsonWireCall (node_modules/wd/lib/webdriver.js:171:13)\n    at [object Object].commands.elements (node_modules/wd/lib/commands.js:811:8)\n    at [object Object].Webdriver.(anonymous function) [as elements](node_modules/wd/lib/webdriver.js:225:15)\n    at [object Object].elements (node_modules/wd/lib/promise-webdriver.js:60:10)\n    at Asserter.assert (node_modules/wd/lib/commands.js:956:15)\n    at Asserter.assert (node_modules/wd/lib/commands.js:870:35)\n    at poll (node_modules/wd/lib/commands.js:884:24)\n    at [object Object].commands.waitFor (node_modules/wd/lib/commands.js:901:3)\n    at [object Object].commands.waitForElement (node_modules/wd/lib/commands.js:978:20)\n    at [object Object].commands.(anonymous function) (node_modules/wd/lib/commands.js:1279:31)\n    at [object Object].Webdriver.(anonymous function) [as waitForElementByCss](node_modules/wd/lib/webdriver.js:225:15)\n    at [object Object].waitForElementByCss (node_modules/wd/lib/promise-webdriver.js:60:10)\n    at operation (node_modules/@wsb/ui-test-framework/lib/setup-chain-methods.js:129:78)\n    at node_modules/@wsb/ui-test-framework/lib/setup-chain-methods.js:131:70\n    at arrayReduce (node_modules/@wsb/ui-test-framework/node_modules/lodash/index.js:1450:23)\n    at Function.<anonymous> (node_modules/@wsb/ui-test-framework/node_modules/lodash/index.js:3445:13)\n    at LodashWrapper.reduce (node_modules/@wsb/ui-test-framework/node_modules/lodash/index.js:11369:27)\n    at node_modules/@wsb/ui-test-framework/lib/setup-chain-methods.js:118:12\n    at [object Object].selectPageElement (node_modules/@wsb/ui-test-framework/lib/setup-chain-methods.js:134:7)\n    at [object Object].wrappedMethod [as element](node_modules/wd/lib/main.js:141:32)\n    at Object.isViewMySiteDisplayed (test/ui/pages/publish.js:53:25)\n    at [object Object].wrappedMethod [as isViewMySiteDisplayed](node_modules/wd/lib/main.js:141:32)\n    at node_modules/wd/lib/promise-webdriver.js:196:35\n    at _fulfilled (node_modules/q/q.js:834:54)\n    at self.promiseDispatch.done (node_modules/q/q.js:863:30)\n    at Promise.promise.promiseDispatch (node_modules/q/q.js:796:13)\n    at node_modules/q/q.js:604:44\n    at runSingle (node_modules/q/q.js:137:13)\n    at flush (node_modules/q/q.js:125:13)",
